### PR TITLE
Bug fix in copy_artifact

### DIFF
--- a/examples/test_utils.py
+++ b/examples/test_utils.py
@@ -1,9 +1,10 @@
 import os
+import uuid
 import shutil
 from pathlib import Path
 
 import pytest
-from dflow import copy_artifact, upload_artifact
+from dflow import copy_artifact, upload_artifact, S3Artifact
 from dflow.utils import catalog_of_artifact, run_command, set_directory
 
 
@@ -55,3 +56,16 @@ def test_copy_artifact():
 
     os.remove("foo.txt")
     os.remove("bar.txt")
+
+
+def test_copy_artifact_dst_none():
+    with open("foo_1.txt", "w"):
+        pass
+    art_1 = S3Artifact(key=f"test-{uuid.uuid4()}")
+    art_2 = upload_artifact(["foo_1.txt"], archive=None)
+    copy_artifact(art_2, art_1, sort=True)
+    catalog = catalog_of_artifact(art_1)
+    catalog.sort(key=lambda x: x["order"])
+    assert catalog == [{'dflow_list_item': 'foo_1.txt', 'order': 0}]
+
+    os.remove("foo_1.txt")

--- a/src/dflow/utils.py
+++ b/src/dflow/utils.py
@@ -167,9 +167,12 @@ def copy_artifact(src, dst, sort=False) -> S3Artifact:
     if sort:
         src_catalog = catalog_of_artifact(src)
         dst_catalog = catalog_of_artifact(dst)
-        if src_catalog and dst_catalog:
-            offset = max(dst_catalog,
-                         key=lambda item: item["order"])["order"] + 1
+        if src_catalog:
+            if dst_catalog:
+                offset = max(dst_catalog,
+                            key=lambda item: item["order"])["order"] + 1
+            else:
+                offset = 0
             for item in src_catalog:
                 item["order"] += offset
             with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
I find a bug in `copy_artifact` when `sort=True` and dst artifact is a manually initialized one. This is caused by `dst_catalog` is `[]` and I tried to fix it.