### PR TITLE
ci: add release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
 name: release-please
 jobs:
   release-please:
+    if: github.repository_owner == 'deepmodeling'
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches:
+      - master
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: simple
+          package-name: release-please-action
+          version-file: "VERSION"


### PR DESCRIPTION
Add release-please action as in #35.
See https://github.com/saltball/dflow/pull/1 for preview(without disable action). 
I add `if: github.repository_owner == 'deepmodeling'` to avoid running on any forked branch.

# TODO

- [ ] docs for developers to use [Conventional Commit messages](https://www.conventionalcommits.org/). I'm not sure how dflow developers organize the docs for contributors.