### PR TITLE
Use raw string to make the cross-platform path behaviors right.

### DIFF
--- a/src/dflow/python/python_op_template.py
+++ b/src/dflow/python/python_op_template.py
@@ -367,7 +367,7 @@ class PythonOPTemplate(PythonScriptOPTemplate):
         script = ""
         if self.python_packages:
             script += "import os, sys, json\n"
-            script += "package_root = '%s/inputs/artifacts/"\
+            script += "package_root = r'%s/inputs/artifacts/"\
                 "dflow_python_packages'\n" % self.tmp_root
             script += "catalog_dir = os.path.join(package_root, "\
                 "'%s')\n" % config['catalog_dir_name']
@@ -442,12 +442,12 @@ class PythonOPTemplate(PythonScriptOPTemplate):
                 if self.slices is not None and self.slices.sub_path and \
                         name in self.slices.input_artifact:
                     script += "    input['%s'] = handle_input_artifact('%s', "\
-                        "input_sign['%s'], %s, '%s', '{{inputs.parameters."\
+                        "input_sign['%s'], %s, r'%s', '{{inputs.parameters."\
                         "dflow_%s_sub_path}}', None)\n" % (
                             name, name, name, slices, self.tmp_root, name)
                 else:
                     script += "    input['%s'] = handle_input_artifact('%s', "\
-                        "input_sign['%s'], %s, '%s', None, %s)\n" \
+                        "input_sign['%s'], %s, r'%s', None, %s)\n" \
                         % (name, name, name, slices, self.tmp_root,
                            self.n_parts.get(name, None))
             else:
@@ -455,13 +455,13 @@ class PythonOPTemplate(PythonScriptOPTemplate):
                 if isinstance(sign, BigParameter) and \
                         config["mode"] != "debug":
                     script += "    input['%s'] = handle_input_parameter('%s',"\
-                        " '', input_sign['%s'], %s, '%s')\n" \
+                        " '', input_sign['%s'], %s, r'%s')\n" \
                         % (name, name, name, slices, self.tmp_root)
                 else:
                     script += "    input['%s'] = handle_input_parameter('%s',"\
                         " r'''{{inputs.parameters.%s}}''', input_sign['%s'], "\
-                        "%s, '%s')\n" % (name, name, name, name, slices,
-                                         self.tmp_root)
+                        "%s, r'%s')\n" % (name, name, name, name, slices,
+                                          self.tmp_root)
 
         script += "    try:\n"
         if self.slices is not None and self.slices.pool_size is not None:
@@ -516,21 +516,21 @@ class PythonOPTemplate(PythonScriptOPTemplate):
         script += "        traceback.print_exc()\n"
         script += "        sys.exit(2)\n"
 
-        script += "    os.makedirs('%s/outputs/parameters', exist_ok=True)\n" \
+        script += "    os.makedirs(r'%s/outputs/parameters', exist_ok=True)\n"\
             % self.tmp_root
-        script += "    os.makedirs('%s/outputs/artifacts', exist_ok=True)\n" \
+        script += "    os.makedirs(r'%s/outputs/artifacts', exist_ok=True)\n" \
             % self.tmp_root
         for name, sign in output_sign.items():
             if isinstance(sign, Artifact):
                 slices = self.get_slices(output_artifact_slices, name)
                 script += "    handle_output_artifact('%s', output['%s'], "\
-                    "output_sign['%s'], %s, '%s')\n" % (name, name, name,
-                                                        slices, self.tmp_root)
+                    "output_sign['%s'], %s, r'%s')\n" % (name, name, name,
+                                                         slices, self.tmp_root)
             else:
                 slices = self.get_slices(output_parameter_slices, name)
                 script += "    handle_output_parameter('%s', output['%s'], "\
-                    "output_sign['%s'], %s, '%s')\n" % (name, name, name,
-                                                        slices, self.tmp_root)
+                    "output_sign['%s'], %s, r'%s')\n" % (name, name, name,
+                                                         slices, self.tmp_root)
         if config["lineage"]:
             if self.slices is not None and self.slices.register_first_only:
                 if "{{item}}" in self.dflow_vars:
@@ -554,7 +554,7 @@ class PythonOPTemplate(PythonScriptOPTemplate):
                         "parameters.dflow_%s_urn}}'\n" % (name, name)
             script += "        handle_lineage('{{workflow.name}}', "\
                 "'{{pod.name}}', op_obj, input_urns, '{{workflow.parameters."\
-                "dflow_workflow_urn}}', '%s')\n" % self.tmp_root
+                "dflow_workflow_urn}}', r'%s')\n" % self.tmp_root
 
         self.script = script
 

--- a/src/dflow/util_ops.py
+++ b/src/dflow/util_ops.py
@@ -66,10 +66,10 @@ class InitArtifactForSlices(PythonScriptOPTemplate):
     def render_script(self):
         script = "import os, json\n"
         for name in self.sliced_output_artifact:
-            script += "os.makedirs('%s/outputs/artifacts/%s/%s', "\
+            script += "os.makedirs(r'%s/outputs/artifacts/%s/%s', "\
                 "exist_ok=True)\n" % (self.tmp_root, name,
                                       config["catalog_dir_name"])
-            script += "with open('%s/outputs/artifacts/%s/%s/init',"\
+            script += "with open(r'%s/outputs/artifacts/%s/%s/init',"\
                 " 'w') as f:\n" % (self.tmp_root, name,
                                    config["catalog_dir_name"])
             script += "    json.dump({'path_list': []}, f)\n"
@@ -77,7 +77,7 @@ class InitArtifactForSlices(PythonScriptOPTemplate):
         if self.sliced_input_artifact:
             for i, name in enumerate(self.sliced_input_artifact):
                 script += "path_list_%s = []\n" % i
-                script += "path = '%s/inputs/artifacts/%s'\n" % \
+                script += "path = r'%s/inputs/artifacts/%s'\n" % \
                     (self.tmp_root, name)
                 script += "if os.path.exists(path):\n"
                 script += "    for f in os.listdir(path):\n"
@@ -100,9 +100,9 @@ class InitArtifactForSlices(PythonScriptOPTemplate):
                 script += "    item['%s'] = path_list_%s[i]"\
                     "['dflow_list_item']\n" % (name, i)
             script += "    slices_path.append(item)\n"
-            script += "os.makedirs('%s/outputs/parameters', exist_ok=True)\n"\
+            script += "os.makedirs(r'%s/outputs/parameters', exist_ok=True)\n"\
                 % self.tmp_root
-            script += "with open('%s/outputs/parameters/dflow_slices_path',"\
+            script += "with open(r'%s/outputs/parameters/dflow_slices_path',"\
                 " 'w') as f:\n" % self.tmp_root
             script += "    json.dump(slices_path, f)\n"
 
@@ -116,8 +116,8 @@ if "dflow_list_item" in value:
     var = list(map(lambda x: x['dflow_list_item'], dflow_list))
 else:
     var = json.loads(value)
-os.makedirs('%s/outputs/parameters', exist_ok=True)
-with open('%s/outputs/parameters/sum_%s', 'w') as f:
+os.makedirs(r'%s/outputs/parameters', exist_ok=True)
+with open(r'%s/outputs/parameters/sum_%s', 'w') as f:
     f.write(str(sum(map(int, var))))\n""" % (
                 name, self.tmp_root, self.tmp_root, name)
 
@@ -135,8 +135,8 @@ else:
             var += json.loads(item)
         else:
             var += item
-os.makedirs('%s/outputs/parameters', exist_ok=True)
-with open('%s/outputs/parameters/concat_%s', 'w') as f:
+os.makedirs(r'%s/outputs/parameters', exist_ok=True)
+with open(r'%s/outputs/parameters/concat_%s', 'w') as f:
     f.write(json.dumps(var))\n""" % (
                 name, self.tmp_root, self.tmp_root, name)
 


### PR DESCRIPTION
The path sometimes work in wrong way and raise error on Windows.

~I'm trying to replace all `os.path` to `pathlib.Path`, which makes the codes working right way on Windows. Because of the `python_requires>=3.6` declared in setup.py, I think `pathlib` should be fully operational for all dflow users. See https://docs.python.org/3/library/pathlib.html#module-pathlib for details.~

~It is ongoing because there may be some special logic like L146-158 in `src/dflow/utils.py` that I'm not so sure how they works. pathlib offers some special function like `is_relative_to` may help `dflow` to deal with files and directories.~

~Some codes in `plugins` has not been changed yet.~