### PR TITLE
fix: bump typeguard to >=3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ six
 python-dateutil
 urllib3
 certifi
-typeguard==2.13.3
+typeguard>=3
 argo-workflows==5.0.0
 jsonpickle
 minio

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ tqdm
 psutil
 typing-extensions
 importlib-metadata
+zipp

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ cloudpickle==2.2.0
 requests
 tqdm
 psutil
+typing-extensions
+importlib-metadata

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "python-dateutil",
         "urllib3",
         "certifi",
-        "typeguard==2.13.3",
+        "typeguard>=3",
         "argo-workflows==5.0.0",
         "jsonpickle",
         "minio",

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup(
         "requests",
         "tqdm",
         "psutil",
+        "typing-extensions",
+        "importlib-metadata",
     ],
     entry_points={
         'console_scripts': ['dflow=dflow.main:main'],

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "psutil",
         "typing-extensions",
         "importlib-metadata",
+        "zipp",
     ],
     entry_points={
         'console_scripts': ['dflow=dflow.main:main'],

--- a/src/dflow/python/op.py
+++ b/src/dflow/python/op.py
@@ -13,7 +13,7 @@ from importlib import import_module
 from pathlib import Path
 from typing import Dict, List, Set, Union
 
-from typeguard import check_type
+from typeguard import check_type, TypeCheckError
 
 from ..argo_objects import ArgoObjectDict
 from ..config import config
@@ -195,7 +195,12 @@ class OP(ABC):
                 ss = ss.type
             # skip type checking if the variable is None
             if io is not None:
-                check_type(ii, io, ss)
+                try:
+                    check_type(io, ss)
+                except TypeCheckError as e:
+                    raise TypeCheckError(
+                        f"Type of {ii} is incorrect: {e}"
+                    ) from e
 
     @classmethod
     def function(cls, func=None, **kwargs):

--- a/src/dflow/python/python_op_template.py
+++ b/src/dflow/python/python_op_template.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 import jsonpickle
 import typeguard
+import typing_extensions
+import importlib_metadata
 
 from .. import __path__
 from ..common import S3Artifact
@@ -339,6 +341,8 @@ class PythonOPTemplate(PythonScriptOPTemplate):
             python_packages += __path__
             python_packages += jsonpickle.__path__
             python_packages += typeguard.__path__
+            python_packages += importlib_metadata.__path__
+            python_packages += typing_extensions.__path__
 
         self.python_packages = None
         if python_packages:

--- a/src/dflow/python/python_op_template.py
+++ b/src/dflow/python/python_op_template.py
@@ -8,6 +8,7 @@ import jsonpickle
 import typeguard
 import typing_extensions
 import importlib_metadata
+import zipp
 
 from .. import __path__
 from ..common import S3Artifact
@@ -343,6 +344,7 @@ class PythonOPTemplate(PythonScriptOPTemplate):
             python_packages += typeguard.__path__
             python_packages += importlib_metadata.__path__
             python_packages += typing_extensions.__path__
+            python_packages += zipp.__path__
 
         self.python_packages = None
         if python_packages:


### PR DESCRIPTION
I am implementing a new feature into dargs in https://github.com/deepmodeling/dargs/pull/37, which requires typeguard>=3, and I hope there are no compatibility issues.