### PR TITLE
fix_typo install_manual_linuxos.md

### DIFF
--- a/tutorials/install_manual_linuxos.md
+++ b/tutorials/install_manual_linuxos.md
@@ -36,7 +36,7 @@ This guide is copied from: https://docs.docker.com/engine/install/ubuntu/#instal
     ```console
     echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-      (lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     ```
 
 #### Install Docker Engine


### PR DESCRIPTION
 Lacking of `$` before (...) wrote the the command (...) into `docker.list` instead of the wanted output of the command, and the following `apt install` broke which checks `docker.list`