### PR TITLE
fix: `op.function` doesn't work with slices.

### DIFF
--- a/src/dflow/python/op.py
+++ b/src/dflow/python/op.py
@@ -212,11 +212,11 @@ class OP(ABC):
 
             @classmethod
             def get_input_sign(cls):
-                return input_sign
+                return deepcopy(input_sign)
 
             @classmethod
             def get_output_sign(cls):
-                return output_sign
+                return deepcopy(output_sign)
 
             @OP.exec_sign_check
             def execute(self, op_in):


### PR DESCRIPTION
This PR addresses the issues encountered when defining an `OP` using `OP.function` and utilizing the `slices` feature, although it has not been thoroughly tested yet.

dflow version: 1.8.67.

I have noticed that functions decorated with the `@OP.function` decorator raising an error with `slices`, such as `"TypeError: the type of <redacted> must be a list; got pathlib.PosixPath instead."`

I have traced the issue to (notice Line515&518) https://github.com/deepmodeling/dflow/blob/8c8c1b78490fd5edf0768bf389163587458098f8/src/dflow/python/python_op_template.py#L503-L519. Specifically, the code in this section has no impact on the `get_input_sign` of class method defined using a Python class, as it returns an actual dictionary returned by the class method, which is created when calling it. **However**, the behavior is different within `OP.function` due to some interesting things of Python functions. Methods defined within library class methods in `python_op_template.py` and those created within class methods defined in the `__main__` scope do not behave consistently, leading to different behavior when executed within a container. If the OP is defined by `OP.function` and attempts to use the slices feature, the Python interpreter alters the input type of the OP, where `input_sign` will be changed because it is returned by `get_input_sign` instead of a copy.

I propose to protect it using deepcopy() in this PR, but I am not certain if there are any other implications.

--------------
P.S. for quick check the behavior in `render_script`:

```python
from pathlib import Path

from dflow.python import (
    OP,
    OPIO,
    Artifact,
    OPIOSign,
)
from typing import List
from copy import deepcopy


@OP.function
def someOP(
    input_file: Artifact(Path),
) -> {"output_file": Artifact(Path)}:
    input_file = input_file['input_file']
    output_file = Path(input_file.stem + ".out")
    ...
    return OPIO({
        "output_file": output_file,
    })


input_sign = someOP.get_input_sign()
# input_sign = deepcopy(someOP.get_input_sign())
print(someOP.get_input_sign())
input_sign['input_file'].type = List[Path]
print(someOP.get_input_sign())


class someOP(OP):
    @classmethod
    def get_input_sign(cls):
        return OPIOSign({
            "input_file": Artifact(Path),
        })

    @classmethod
    def get_output_sign(cls):
        return OPIOSign({
            "output_file": Artifact(Path),
        })

    @OP.exec_sign_check
    def execute(
            self,
            ip: OPIO,
    ) -> OPIO:
        input_file = ip['input_file']
        output_file = Path(input_file.stem + ".out")
        ...
        return OPIO({
            "output_file": output_file,
        })


print('=====')
input_sign = someOP.get_input_sign()
print(someOP.get_input_sign())
input_sign['input_file'].type = List[Path]
print(someOP.get_input_sign())
```
expect:
```
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
=====
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
```
but: 
```
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
{'input_file': Artifact(type=typing.List, optional=False, sub_path=True)}
=====
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
{'input_file': Artifact(type=pathlib.Path, optional=False, sub_path=True)}
```