### PR TITLE
fix: continue_on_success_ratio without slice raise error

### DIFF
--- a/src/dflow/step.py
+++ b/src/dflow/step.py
@@ -588,7 +588,7 @@ class Step:
                 else:
                     for name in sliced_input_artifact:
                         self.inputs.parameters["dflow_%s_sub_path" %
-                                            name].value = "{{item.%s}}" % name
+                                               name].value = "{{item.%s}}" % name
                         v = self.inputs.artifacts[name].source
                         if isinstance(v, S3Artifact):
                             self.prepare_step.set_artifacts({
@@ -702,7 +702,8 @@ class Step:
                 self.template.set_slices(self.template.slices)
                 self.with_param = argo_range(if_expression(
                     "%s %% %s > 0" % (nslices, group_size),
-                    "%s/%s + 1" % (nslices, group_size),
+                    "(%s - %s %% %s) / %s + 1" % (nslices,
+                                                  nslices, group_size, group_size),
                     "%s/%s" % (nslices, group_size)))
             elif self.with_param is not None:
                 self.template.inputs.parameters["dflow_with_param"] = \
@@ -725,7 +726,8 @@ class Step:
                 self.template.set_slices(self.template.slices)
                 self.with_param = argo_range(if_expression(
                     "%s %% %s > 0" % (nslices, group_size),
-                    "%s/%s + 1" % (nslices, group_size),
+                    "(%s - %s %% %s) / %s + 1" % (nslices,
+                                                  nslices, group_size, group_size),
                     "%s/%s" % (nslices, group_size)))
             if self.with_sequence is not None:
                 self.template.inputs.parameters["dflow_sequence_start"] = \
@@ -779,7 +781,8 @@ class Step:
                 self.with_sequence = argo_sequence(
                     count=if_expression(
                         "%s %% %s > 0" % (nslices, group_size),
-                        "%s/%s + 1" % (nslices, group_size),
+                        "(%s - %s %% %s) / %s + 1" % (nslices,
+                                                      nslices, group_size, group_size),
                         "%s/%s" % (nslices, group_size)), format=format)
 
             self.inputs.parameters["dflow_nslices"] = InputParameter(
@@ -912,6 +915,7 @@ class Step:
                 }
             )
         elif self.continue_on_success_ratio is not None:
+            total = 1
             if "dflow_nslices" in self.inputs.parameters:
                 total = self.inputs.parameters["dflow_nslices"].value
             elif self.with_param is not None:


### PR DESCRIPTION
For some conditions, the slice expression do not worked for if_expression when combining and split the job groups. This PR tries to fix this.
The problem hardly effect the normal users especially the executor users. I'll check it further and provide details later.