### PR TITLE
fix(argo_objects.py): prevent recursion explosion in get_sub_nodes traversal

### DIFF
--- a/src/dflow/argo_objects.py
+++ b/src/dflow/argo_objects.py
@@ -454,7 +454,7 @@ class ArgoWorkflow(ArgoObjectDict):
                 if id not in outbound_nodes:
                     next_generation += self.status.nodes[id].get(
                         "children", [])
-            current_generation = next_generation
+            current_generation = list(set(next_generation))
         return sub_nodes
 
     def get_duration(self) -> datetime.timedelta:


### PR DESCRIPTION
The loop in get_sub_nodes caused exponential growth of current_generation, when children lists contained duplicate node IDs, leading to:

1. Iter 1: 1 node → 100 children
2. Iter 2: 100 nodes → 100 identical children (each repeated)
3. Subsequent iterations grew with exponentially increasing duplicate entries

Fixed by:
- Adding deduplication via list(set(next_generation))