### PR TITLE
print variables when failed to evaluate expression

### DIFF
--- a/src/dflow/io.py
+++ b/src/dflow/io.py
@@ -85,7 +85,7 @@ class Expression:
         try:
             res = eval(self.expr, variables)
         except Exception:
-            raise RuntimeError("Failed to evaluate expression %s", self.expr)
+            raise RuntimeError("Failed to evaluate expression %s with variables %s" % (self.expr, variables))
         return res
 
 


### PR DESCRIPTION
It's hard to debug if the variables are not printed.